### PR TITLE
Add PSGI Streaming - Updated

### DIFF
--- a/lib/CGI/Application.pm
+++ b/lib/CGI/Application.pm
@@ -199,7 +199,7 @@ sub run {
 
 	my $return_value;
 	if ($self->{__IS_PSGI}) {
-		my ($status, $headers) = $self->_send_psgi_headers();
+		my ($status, $headers) = $self->send_psgi_headers();
 
 		if (ref($body) eq 'GLOB' || (Scalar::Util::blessed($body) && $body->can('getline'))) {
 			# body a file handle - return it
@@ -658,7 +658,7 @@ sub _send_headers {
 }
 
 # return a 2 element array modeling the first PSGI redirect values: status code and arrayref of header pairs
-sub _send_psgi_headers {
+sub send_psgi_headers {
 	my $self = shift;
 	my $q    = $self->query;
 	my $type = $self->header_type;
@@ -1114,7 +1114,7 @@ The PSGI Specification allows for returning a file handle or a subroutine refere
 
         return sub {
            my $respond = shift;
-           my $writer = $respond->([ $self->_send_psgi_header ]);
+           my $writer = $respond->([ $self->send_psgi_headers ]);
 
            foreach my $i (1..10) {
                #sleep 1;
@@ -2064,6 +2064,15 @@ changes to the mode under specific conditions.
 B<Note:>  The prerun_mode() method may ONLY be called in the context of
 a cgiapp_prerun() method.  Your application will die() if you call
 prerun_mode() elsewhere, such as in setup() or a run mode method.
+
+=head3 send_psgi_headers()
+
+    my ($http_status_code, $headers_aref) = $self->send_psgi_headers;
+
+This method generates PSGI headers based on header_type and header_props. It is
+normally called automatically for you. However, you may call it directly if you
+are using the coderef return value option, and writing your own callback to
+generate the headers.
 
 =head2 Dispatching Clean URIs to run modes
 

--- a/t/lib/TestApp_PSGI_Callback.pm
+++ b/t/lib/TestApp_PSGI_Callback.pm
@@ -32,9 +32,8 @@ sub callback_subref {
     return sub {
        my $respond = shift;
 
-       #my $writer = $respond->([200, ['Content-Type' => 'text/plain']]);   # this works fine
-       #my $writer = $respond->([ $self->query->psgi_header ]);             # this doesn't work?
-       my $writer = $respond->([ $self->_send_psgi_headers ]);              # this works, but uses an internal call - perhaps it should be made public?
+       #my $writer = $respond->([200, ['Content-Type' => 'text/plain']]);  # this method is fine
+       my $writer = $respond->([ $self->send_psgi_headers ]);              # using cgi-app header props
        foreach my $i (1..10) {
            #sleep 1;
            $writer->write("check $i: " . time . "\n");

--- a/t/psgi_streaming_callback.t
+++ b/t/psgi_streaming_callback.t
@@ -5,7 +5,7 @@ use Test::Requires qw(Plack::Loader LWP::UserAgent);
 use Test::TCP;
 
 use TestApp_PSGI_Callback;
-use CGI::Application::PSGI;
+use CGI::PSGI;
 
 my $test_file = 't/test_file_to_stream.txt';
 


### PR DESCRIPTION
Refactored so that when $body is a subref, we just return it.

Updated the tests and docs to reflect this. 

I've still a minor question around the headers:

```
   #my $writer = $respond->([200, ['Content-Type' => 'text/plain']]);   # this works fine
   #my $writer = $respond->([ $self->query->psgi_header ]);             # this doesn't work?
   my $writer = $respond->([ $self->_send_psgi_headers ]);              # this works, but uses an internal call - perhaps it should be made public?
```
